### PR TITLE
feat: 이력서 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'com.h2database:h2' // 테스트 시에만 로드

--- a/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceAttachmentController.java
+++ b/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceAttachmentController.java
@@ -1,4 +1,49 @@
-package com.moayo.moayobackend.controller;
+package com.moayo.moayobackend.experience.controller;
 
+import com.moayo.moayobackend.experience.service.ExperienceAttachmentService;
+import com.moayo.moayobackend.experience.dto.request.AttachFileRequest;
+import com.moayo.moayobackend.experience.dto.response.FileAttachmentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/experiences/{experienceId}/attachments/files")
 public class ExperienceAttachmentController {
+
+    private final ExperienceAttachmentService attachmentService;
+
+    // 파일 첨부(연결) - fileId를 받아 experience에 연결
+    @PostMapping
+    public ResponseEntity<Void> attachFile(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId,
+            @RequestBody AttachFileRequest req
+    ) {
+        attachmentService.attachFile(memberId, experienceId, req);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 첨부된 파일 목록 조회
+    @GetMapping
+    public ResponseEntity<List<FileAttachmentResponse>> listFiles(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId
+    ) {
+        return ResponseEntity.ok(attachmentService.listFiles(memberId, experienceId));
+    }
+
+    // 첨부 파일 삭제(연결 해제)
+    @DeleteMapping("/{fileId}")
+    public ResponseEntity<Void> detachFile(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId,
+            @PathVariable Long fileId
+    ) {
+        attachmentService.detachFile(memberId, experienceId, fileId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceController.java
+++ b/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceController.java
@@ -1,4 +1,100 @@
-package com.moayo.moayobackend.controller;
+package com.moayo.moayobackend.experience.controller;
 
+import com.moayo.moayobackend.experience.dto.request.ExperienceAiDraftRequest;
+import com.moayo.moayobackend.experience.dto.response.ExperienceAiDraftResponse;
+import com.moayo.moayobackend.experience.service.ExperienceService;
+import com.moayo.moayobackend.experience.dto.request.ExperienceCreateRequest;
+import com.moayo.moayobackend.experience.dto.request.ExperienceUpdateRequest;
+import com.moayo.moayobackend.experience.dto.request.ExperienceVisibilityRequest;
+import com.moayo.moayobackend.experience.dto.response.ExperienceDetailResponse;
+import com.moayo.moayobackend.experience.dto.response.ExperienceSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
 public class ExperienceController {
+
+    private final ExperienceService experienceService;
+
+    // 내 이력 목록 조회 (카드 리스트)
+    @GetMapping("/experiences")
+    public ResponseEntity<List<ExperienceSummaryResponse>> listMyExperiences(
+            @RequestHeader("X-MEMBER-ID") Long memberId
+    ) {
+        return ResponseEntity.ok(experienceService.listMyExperiences(memberId));
+    }
+
+    // 이력 생성 (이력 추가 페이지 등록하기)
+    @PostMapping("/experiences")
+    public ResponseEntity<Void> create(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @RequestBody ExperienceCreateRequest req
+    ) {
+        Long id = experienceService.create(memberId, req);
+        return ResponseEntity.created(URI.create("/api/v1/experiences/" + id)).build();
+    }
+
+    // 이력 상세 조회 (카드 클릭 -> 팝업 열기)
+    @GetMapping("/experiences/{experienceId}")
+    public ResponseEntity<ExperienceDetailResponse> getDetail(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId
+    ) {
+        return ResponseEntity.ok(experienceService.getMyDetail(memberId, experienceId));
+    }
+
+    // 이력 수정 저장 (수정 페이지 저장하기)
+    @PatchMapping("/experiences/{experienceId}")
+    public ResponseEntity<Void> update(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId,
+            @RequestBody ExperienceUpdateRequest req
+    ) {
+        experienceService.update(memberId, experienceId, req);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 이력 삭제 (팝업에서 삭제하기)
+    @DeleteMapping("/experiences/{experienceId}")
+    public ResponseEntity<Void> delete(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId
+    ) {
+        experienceService.delete(memberId, experienceId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 이력 공개/비공개 토글
+    @PatchMapping("/experiences/{experienceId}/visibility")
+    public ResponseEntity<Void> changeVisibility(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId,
+            @RequestBody ExperienceVisibilityRequest req
+    ) {
+        experienceService.changeVisibility(memberId, experienceId, req);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 타인 프로필: 공개 이력만 조회
+    @GetMapping("/users/{userId}/experiences")
+    public ResponseEntity<List<ExperienceSummaryResponse>> listPublicByUser(
+            @PathVariable Long userId
+    ) {
+        return ResponseEntity.ok(experienceService.listPublicByUser(userId));
+    }
+
+    @PostMapping("/{experienceId}/ai/draft")
+    public ResponseEntity<ExperienceAiDraftResponse> draftWithAi(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId,
+            @RequestBody(required = false) ExperienceAiDraftRequest req
+    ) {
+        return ResponseEntity.ok(experienceService.draftWithAi(memberId, experienceId, req));
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceLinkController.java
+++ b/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceLinkController.java
@@ -1,4 +1,62 @@
-package com.moayo.moayobackend.controller;
+package com.moayo.moayobackend.experience.controller;
 
+import com.moayo.moayobackend.experience.service.ExperienceLinkService;
+import com.moayo.moayobackend.experience.dto.request.ExperienceLinkCreateRequest;
+import com.moayo.moayobackend.experience.dto.request.ExperienceLinkUpdateRequest;
+import com.moayo.moayobackend.experience.dto.response.ExperienceLinkResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/experiences/{experienceId}/attachments/links")
 public class ExperienceLinkController {
+
+    private final ExperienceLinkService linkService;
+
+    // 링크 추가
+    @PostMapping
+    public ResponseEntity<Void> createLink(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId,
+            @RequestBody ExperienceLinkCreateRequest req
+    ) {
+        linkService.create(memberId, experienceId, req);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 링크 목록 조회
+    @GetMapping
+    public ResponseEntity<List<ExperienceLinkResponse>> listLinks(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId
+    ) {
+        return ResponseEntity.ok(linkService.list(memberId, experienceId));
+    }
+
+    // 링크 수정
+    @PatchMapping("/{linkId}")
+    public ResponseEntity<Void> updateLink(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId,
+            @PathVariable Long linkId,
+            @RequestBody ExperienceLinkUpdateRequest req
+    ) {
+        linkService.update(memberId, experienceId, linkId, req);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 링크 삭제
+    @DeleteMapping("/{linkId}")
+    public ResponseEntity<Void> deleteLink(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @PathVariable Long experienceId,
+            @PathVariable Long linkId
+    ) {
+        linkService.delete(memberId, experienceId, linkId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/dto/request/AttachFileRequest.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/request/AttachFileRequest.java
@@ -1,4 +1,6 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.request;
 
-public class AttachFileRequest {
-}
+public record AttachFileRequest(
+        Long fileId,
+        String fileName
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceAiDraftRequest.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceAiDraftRequest.java
@@ -1,4 +1,5 @@
 package com.moayo.moayobackend.experience.dto.request;
 
-public class ExperienceAiDraftRequest {
-}
+public record ExperienceAiDraftRequest(
+        String prompt
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceCreateRequest.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceCreateRequest.java
@@ -1,4 +1,13 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.request;
 
-public class ExperienceCreateRequest {
-}
+import java.time.LocalDate;
+
+public record ExperienceCreateRequest(
+        String title,
+        String organization,
+        LocalDate startDate,
+        LocalDate endDate,
+        String activity,
+        String role,
+        String summary
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceLinkCreateRequest.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceLinkCreateRequest.java
@@ -1,4 +1,6 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.request;
 
-public class ExperienceLinkCreateRequest {
-}
+public record ExperienceLinkCreateRequest(
+        String title,
+        String url
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceLinkUpdateRequest.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceLinkUpdateRequest.java
@@ -1,4 +1,6 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.request;
 
-public class ExperienceLinkUpdateRequest {
-}
+public record ExperienceLinkUpdateRequest(
+        String title,
+        String url
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceUpdateRequest.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceUpdateRequest.java
@@ -1,4 +1,13 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.request;
 
-public class ExperienceUpdateRequest {
-}
+import java.time.LocalDate;
+
+public record ExperienceUpdateRequest(
+        String title,
+        String organization,
+        LocalDate startDate,
+        LocalDate endDate,
+        String activity,
+        String role,
+        String summary
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceVisibilityRequest.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/request/ExperienceVisibilityRequest.java
@@ -1,4 +1,5 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.request;
 
-public class ExperienceVisibilityRequest {
-}
+public record ExperienceVisibilityRequest(
+        Boolean visible
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/response/ExperienceAiDraftResponse.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/response/ExperienceAiDraftResponse.java
@@ -1,4 +1,13 @@
-package com.moayo.moayobackend.experience.dto.request;
+package com.moayo.moayobackend.experience.dto.response;
 
-public class ExperienceAiDraftResponse {
-}
+import java.time.LocalDate;
+
+public record ExperienceAiDraftResponse(
+        String organization,
+        String title,
+        String activity,
+        String role,
+        String summary,
+        LocalDate startDate,
+        LocalDate endDate
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/response/ExperienceDetailResponse.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/response/ExperienceDetailResponse.java
@@ -1,4 +1,15 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.response;
 
-public class ExperienceDetailResponse {
-}
+import java.time.LocalDate;
+
+public record ExperienceDetailResponse(
+        Long experienceId,
+        String title,
+        String organization,
+        LocalDate startDate,
+        LocalDate endDate,
+        String activity,
+        String role,
+        String summary,
+        Boolean visible
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/response/ExperienceLinkResponse.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/response/ExperienceLinkResponse.java
@@ -1,4 +1,7 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.response;
 
-public class ExperienceLinkResponse {
-}
+public record ExperienceLinkResponse(
+        Long linkId,
+        String title,
+        String url
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/response/ExperienceSummaryResponse.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/response/ExperienceSummaryResponse.java
@@ -1,4 +1,14 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.response;
 
-public class ExperienceSummaryResponse {
-}
+import java.time.LocalDate;
+
+public record ExperienceSummaryResponse(
+        Long experienceId,
+        String organization,
+        String title,
+        LocalDate startDate,
+        LocalDate endDate,
+        String activity,
+        String role,
+        Boolean visible
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/dto/response/FileAttachmentResponse.java
+++ b/src/main/java/com/moayo/moayobackend/experience/dto/response/FileAttachmentResponse.java
@@ -1,4 +1,6 @@
-package com.moayo.moayobackend.experience.dto;
+package com.moayo.moayobackend.experience.dto.response;
 
-public class FileAttachmentResponse {
-}
+public record FileAttachmentResponse(
+        Long fileId,
+        String fileName
+) {}

--- a/src/main/java/com/moayo/moayobackend/experience/entity/Experience.java
+++ b/src/main/java/com/moayo/moayobackend/experience/entity/Experience.java
@@ -1,4 +1,88 @@
-package com.moayo.moayobackend.entity;
+package com.moayo.moayobackend.experience.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "experience")
 public class Experience {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private String organization; // 주최/기관
+    private String title; // 활동명
+    private String activity; // 참여형태/활동분류
+    private String role; // 역할
+
+    @Column(length = 2000)
+    private String summary;      // 활동 소개
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    private Boolean visible;
+
+    public Experience(Long memberId,
+                      String organization,
+                      String title,
+                      String activity,
+                      String role,
+                      String summary,
+                      LocalDate startDate,
+                      LocalDate endDate,
+                      Boolean visible) {
+        this.memberId = memberId;
+        this.organization = organization;
+        this.title = title;
+        this.activity = activity;
+        this.role = role;
+        this.summary = summary;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.visible = visible;
+    }
+
+    public void validateOwner(Long memberId) {
+        if (this.memberId == null || !this.memberId.equals(memberId)) {
+            throw new IllegalArgumentException("No permission");
+        }
+    }
+
+    public void applyPatch(String organization,
+                           String title,
+                           String activity,
+                           String role,
+                           String summary,
+                           LocalDate startDate,
+                           LocalDate endDate) {
+        if (organization != null)
+            this.organization = organization;
+        if (title != null)
+            this.title = title;
+        if (activity != null)
+            this.activity = activity;
+        if (role != null)
+            this.role = role;
+        if (summary != null)
+            this.summary = summary;
+        if (startDate != null)
+            this.startDate = startDate;
+        if (endDate != null)
+            this.endDate = endDate;
+    }
+
+    public void changeVisibility(Boolean visible) {
+        if (visible != null)
+            this.visible = visible;
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/entity/ExperienceFile.java
+++ b/src/main/java/com/moayo/moayobackend/experience/entity/ExperienceFile.java
@@ -1,4 +1,29 @@
-package com.moayo.moayobackend.entity;
+package com.moayo.moayobackend.experience.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "experience_file")
 public class ExperienceFile {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long experienceId;
+
+    private Long fileId;
+
+    private String fileName;
+
+    public ExperienceFile(Long experienceId, Long fileId, String fileName) {
+        this.experienceId = experienceId;
+        this.fileId = fileId;
+        this.fileName = fileName;
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/entity/ExperienceLink.java
+++ b/src/main/java/com/moayo/moayobackend/experience/entity/ExperienceLink.java
@@ -1,4 +1,37 @@
-package com.moayo.moayobackend.entity;
+package com.moayo.moayobackend.experience.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "experience_link")
 public class ExperienceLink {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long experienceId;
+
+    private String title;
+
+    @Column(length = 1000)
+    private String url;
+
+    public ExperienceLink(Long experienceId, String title, String url) {
+        this.experienceId = experienceId;
+        this.title = title;
+        this.url = url;
+    }
+
+    public void update(String title, String url) {
+        if (title != null)
+            this.title = title;
+        if (url != null)
+            this.url = url;
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceFileRepository.java
+++ b/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceFileRepository.java
@@ -1,4 +1,15 @@
-package com.moayo.moayobackend.repository;
+package com.moayo.moayobackend.experience.repository;
 
-public class ExperienceFileRepository {
+import com.moayo.moayobackend.experience.entity.ExperienceFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExperienceFileRepository extends JpaRepository<ExperienceFile, Long> {
+
+    List<ExperienceFile> findAllByExperienceIdOrderByIdDesc(Long experienceId);
+
+    void deleteByExperienceIdAndFileId(Long experienceId, Long fileId);
+
+    boolean existsByExperienceIdAndFileId(Long experienceId, Long fileId);
 }

--- a/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceLinkRepository.java
+++ b/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceLinkRepository.java
@@ -1,4 +1,14 @@
-package com.moayo.moayobackend.repository;
+package com.moayo.moayobackend.experience.repository;
 
-public class ExperienceLinkRepository {
+import com.moayo.moayobackend.experience.entity.ExperienceLink;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ExperienceLinkRepository extends JpaRepository<ExperienceLink, Long> {
+
+    List<ExperienceLink> findAllByExperienceIdOrderByIdDesc(Long experienceId);
+
+    Optional<ExperienceLink> findByIdAndExperienceId(Long id, Long experienceId);
 }

--- a/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceRepository.java
@@ -1,4 +1,13 @@
-package com.moayo.moayobackend.repository;
+package com.moayo.moayobackend.experience.repository;
 
-public class ExperienceRepository {
+import com.moayo.moayobackend.experience.entity.Experience;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+
+    List<Experience> findAllByMemberIdOrderByIdDesc(Long memberId);
+
+    List<Experience> findAllByMemberIdAndVisibleTrueOrderByIdDesc(Long memberId);
 }

--- a/src/main/java/com/moayo/moayobackend/experience/service/ExperienceAttachmentService.java
+++ b/src/main/java/com/moayo/moayobackend/experience/service/ExperienceAttachmentService.java
@@ -1,4 +1,55 @@
-package com.moayo.moayobackend.service;
+package com.moayo.moayobackend.experience.service;
 
+import com.moayo.moayobackend.experience.dto.request.AttachFileRequest;
+import com.moayo.moayobackend.experience.entity.Experience;
+import com.moayo.moayobackend.experience.entity.ExperienceFile;
+import com.moayo.moayobackend.experience.dto.response.FileAttachmentResponse;
+import com.moayo.moayobackend.experience.repository.ExperienceFileRepository;
+import com.moayo.moayobackend.experience.repository.ExperienceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class ExperienceAttachmentService {
+
+    private final ExperienceRepository experienceRepository;
+    private final ExperienceFileRepository fileRepository;
+
+    @Transactional
+    public void attachFile(Long memberId, Long experienceId, AttachFileRequest req) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        if (req.fileId() == null) throw new IllegalArgumentException("fileId is required");
+
+        boolean exists = fileRepository.existsByExperienceIdAndFileId(experienceId, req.fileId());
+        if (exists) return; // 중복 첨부 방지(원하면 예외로 바꿔도 됨)
+
+        fileRepository.save(new ExperienceFile(experienceId, req.fileId(), req.fileName()));
+    }
+
+    @Transactional(readOnly = true)
+    public List<FileAttachmentResponse> listFiles(Long memberId, Long experienceId) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        return fileRepository.findAllByExperienceIdOrderByIdDesc(experienceId).stream()
+                .map(f -> new FileAttachmentResponse(f.getFileId(), f.getFileName()))
+                .toList();
+    }
+
+    @Transactional
+    public void detachFile(Long memberId, Long experienceId, Long fileId) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        fileRepository.deleteByExperienceIdAndFileId(experienceId, fileId);
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/service/ExperienceLinkService.java
+++ b/src/main/java/com/moayo/moayobackend/experience/service/ExperienceLinkService.java
@@ -1,4 +1,66 @@
-package com.moayo.moayobackend.service;
+package com.moayo.moayobackend.experience.service;
 
+import com.moayo.moayobackend.experience.entity.Experience;
+import com.moayo.moayobackend.experience.entity.ExperienceLink;
+import com.moayo.moayobackend.experience.dto.request.ExperienceLinkCreateRequest;
+import com.moayo.moayobackend.experience.dto.request.ExperienceLinkUpdateRequest;
+import com.moayo.moayobackend.experience.dto.response.ExperienceLinkResponse;
+import com.moayo.moayobackend.experience.repository.ExperienceLinkRepository;
+import com.moayo.moayobackend.experience.repository.ExperienceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class ExperienceLinkService {
+
+    private final ExperienceRepository experienceRepository;
+    private final ExperienceLinkRepository linkRepository;
+
+    @Transactional
+    public void create(Long memberId, Long experienceId, ExperienceLinkCreateRequest req) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        linkRepository.save(new ExperienceLink(experienceId, req.title(), req.url()));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ExperienceLinkResponse> list(Long memberId, Long experienceId) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        return linkRepository.findAllByExperienceIdOrderByIdDesc(experienceId).stream()
+                .map(l -> new ExperienceLinkResponse(l.getId(), l.getTitle(), l.getUrl()))
+                .toList();
+    }
+
+    @Transactional
+    public void update(Long memberId, Long experienceId, Long linkId, ExperienceLinkUpdateRequest req) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        ExperienceLink link = linkRepository.findByIdAndExperienceId(linkId, experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Link not found"));
+
+        link.update(req.title(), req.url());
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long experienceId, Long linkId) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        ExperienceLink link = linkRepository.findByIdAndExperienceId(linkId, experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Link not found"));
+
+        linkRepository.delete(link);
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/service/ExperienceService.java
+++ b/src/main/java/com/moayo/moayobackend/experience/service/ExperienceService.java
@@ -1,4 +1,193 @@
-package com.moayo.moayobackend.service;
+package com.moayo.moayobackend.experience.service;
 
+import com.moayo.moayobackend.experience.dto.request.ExperienceAiDraftRequest;
+import com.moayo.moayobackend.experience.dto.response.ExperienceAiDraftResponse;
+import com.moayo.moayobackend.experience.entity.Experience;
+import com.moayo.moayobackend.experience.dto.request.ExperienceCreateRequest;
+import com.moayo.moayobackend.experience.dto.request.ExperienceUpdateRequest;
+import com.moayo.moayobackend.experience.dto.request.ExperienceVisibilityRequest;
+import com.moayo.moayobackend.experience.dto.response.ExperienceDetailResponse;
+import com.moayo.moayobackend.experience.dto.response.ExperienceSummaryResponse;
+import com.moayo.moayobackend.experience.repository.ExperienceFileRepository;
+import com.moayo.moayobackend.experience.repository.ExperienceLinkRepository;
+import com.moayo.moayobackend.experience.repository.ExperienceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class ExperienceService {
+
+    private final ExperienceRepository experienceRepository;
+    private final OpenAiClient aiServerClient;
+    private final ExperienceFileRepository experienceFileRepository;
+    private final ExperienceLinkRepository experienceLinkRepository;
+
+    @Transactional(readOnly = true)
+    public List<ExperienceSummaryResponse> listMyExperiences(Long memberId) {
+        return experienceRepository.findAllByMemberIdOrderByIdDesc(memberId).stream()
+                .map(e -> new ExperienceSummaryResponse(
+                        e.getId(),
+                        e.getOrganization(),
+                        e.getTitle(),
+                        e.getStartDate(),
+                        e.getEndDate(),
+                        e.getActivity(),
+                        e.getRole(),
+                        e.getVisible()
+                ))
+                .toList();
+    }
+
+    @Transactional
+    public Long create(Long memberId, ExperienceCreateRequest req) {
+        Experience e = new Experience(
+                memberId,
+                req.organization(),
+                req.title(),
+                req.activity(),
+                req.role(),
+                req.summary(),
+                req.startDate(),
+                req.endDate(),
+                true
+        );
+        return experienceRepository.save(e).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ExperienceDetailResponse getMyDetail(Long memberId, Long experienceId) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        return new ExperienceDetailResponse(
+                e.getId(),
+                e.getOrganization(),
+                e.getTitle(),
+                e.getStartDate(),
+                e.getEndDate(),
+                e.getActivity(),
+                e.getRole(),
+                e.getSummary(),
+                e.getVisible()
+        );
+    }
+
+    @Transactional
+    public void update(Long memberId, Long experienceId, ExperienceUpdateRequest req) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        e.applyPatch(
+                req.organization(),
+                req.title(),
+                req.activity(),
+                req.role(),
+                req.summary(),
+                req.startDate(),
+                req.endDate()
+        );
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long experienceId) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        experienceRepository.deleteById(experienceId);
+    }
+
+    @Transactional
+    public void changeVisibility(Long memberId, Long experienceId, ExperienceVisibilityRequest req) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        e.changeVisibility(req.visible());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ExperienceSummaryResponse> listPublicByUser(Long userId) {
+        return experienceRepository.findAllByMemberIdAndVisibleTrueOrderByIdDesc(userId).stream()
+                .map(e -> new ExperienceSummaryResponse(
+                        e.getId(),
+                        e.getOrganization(),
+                        e.getTitle(),
+                        e.getStartDate(),
+                        e.getEndDate(),
+                        e.getActivity(),
+                        e.getRole(),
+                        e.getVisible()
+                ))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ExperienceAiDraftResponse draftWithAi(Long memberId, Long experienceId, ExperienceAiDraftRequest req) {
+        Experience e = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
+        e.validateOwner(memberId);
+
+        // 첨부파일, 링크를 context로 합쳐 AI 품질 올리기
+        var files = experienceFileRepository.findAllByExperienceIdOrderByIdDesc(experienceId);
+        var links = experienceLinkRepository.findAllByExperienceIdOrderByIdDesc(experienceId);
+
+        String context = buildContext(e, files, links);
+        String prompt = (req == null || req.prompt() == null) ? "" : req.prompt();
+
+        // 여기서만 AI 서버 호출, 그리고 결과를 그대로 반환(저장 X)
+        return aiServerClient.generateExperienceDraft(prompt, context);
+    }
+
+    private String buildContext(Experience e,
+                                List<com.moayo.moayobackend.experience.entity.ExperienceFile> files,
+                                List<com.moayo.moayobackend.experience.entity.ExperienceLink> links) {
+
+        String filePart = files.stream()
+                .limit(5)
+                .map(f -> "- " + safe(f.getFileName()) + " (fileId=" + f.getFileId() + ")")
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        String linkPart = links.stream()
+                .limit(5)
+                .map(l -> "- " + safe(l.getTitle()) + " : " + safe(l.getUrl()))
+                .reduce("", (a, b) -> a + "\n" + b);
+
+        return """
+        [Existing Experience]
+        organization=%s
+        title=%s
+        activity=%s
+        role=%s
+        summary=%s
+        startDate=%s
+        endDate=%s
+
+        [Attached Files]
+        %s
+
+        [Attached Links]
+        %s
+        """.formatted(
+                safe(e.getOrganization()),
+                safe(e.getTitle()),
+                safe(e.getActivity()),
+                safe(e.getRole()),
+                safe(e.getSummary()),
+                e.getStartDate(),
+                e.getEndDate(),
+                filePart.isBlank() ? "(none)" : filePart,
+                linkPart.isBlank() ? "(none)" : linkPart
+        );
+    }
+
+    private String safe(String v) {
+        return v == null ? "" : v;
+    }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/service/OpenAiClient.java
+++ b/src/main/java/com/moayo/moayobackend/experience/service/OpenAiClient.java
@@ -1,4 +1,77 @@
 package com.moayo.moayobackend.experience.service;
 
+import com.moayo.moayobackend.experience.dto.response.ExperienceAiDraftResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.netty.http.client.HttpClient;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
 public class OpenAiClient {
+
+    private final WebClient webClient;
+
+    public OpenAiClient(
+            @Value("${ai.server.base-url}") String baseUrl,
+            @Value("${ai.server.api-key:}") String apiKey
+    ) {
+        HttpClient httpClient = HttpClient.create()
+                .responseTimeout(Duration.ofSeconds(15));
+
+        WebClient.Builder builder = WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+        if (apiKey != null && !apiKey.isBlank()) {
+            builder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
+        }
+
+        this.webClient = builder.build();
+    }
+
+    /**
+     * 내부 AI 서버 응답(flat JSON)
+     * {
+     *   "organization": "...",
+     *   "title": "...",
+     *   "activity": "...",
+     *   "role": "...",
+     *   "summary": "...",
+     *   "startDate": "2024-08-13",
+     *   "endDate": "2024-10-02"
+     * }
+     */
+    public ExperienceAiDraftResponse generateExperienceDraft(String prompt, String context) {
+        AiServerDraftRequest body = new AiServerDraftRequest(prompt, context);
+
+        try {
+            return webClient.post()
+                    .uri("/v1/experience/draft")
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(ExperienceAiDraftResponse.class)
+                    .block(Duration.ofSeconds(20));
+
+        } catch (WebClientResponseException e) {
+            // AI 서버가 에러응답(400번대, 500번대)을 내려준 경우
+            log.error("AI server error: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IllegalStateException("AI server error: " + e.getStatusCode());
+
+        } catch (Exception e) {
+            // 타임아웃, 연결 실패 등
+            log.error("AI server call failed", e);
+            throw new IllegalStateException("AI server call failed");
+        }
+    }
+
+    public record AiServerDraftRequest(String prompt, String context) {}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+ai:
+  server:
+    base-url: "http://localhost:9999"   # 일단 더미
+    api-key: ""                         # 없어도 됨


### PR DESCRIPTION
✅ 작업 요약
- 이력서(Experience) 도메인의 핵심 기능인 CRUD(등록, 조회, 수정, 삭제) API 구현
- 첨부 파일, 링크 관리 및 AI 기반 이력 draft 생성 기능 연동
- 이력 작성 및 수정 플로우 완성
- 공개/비공개 설정, 상세/요약 조회 분리, AI draft 결과를 수정 페이지에 임시 반영하는 구조 설계 및 구현

🔗 관련 이슈
- Closes https://github.com/moayo-team/moayo-backend/issues/36

🧩 주요 변경 사항

1. Experience 도메인
- Experience 엔티티 CRUD API 구현
- 공개/비공개(visible) 토글 API 추가
- 상세 조회 / 요약 조회 응답 DTO 분리

2. 첨부 파일 & 링크
- ExperienceFile / ExperienceLink 엔티티 및 Repository 구현
- 첨부 파일 등록 API
- 링크 등록/수정/조회 API 분리 구현

3. AI Draft 기능
- ExperienceAiDraftRequest / Response DTO 정의
- OpenAiClient를 통한 AI draft 생성 API 연동
- AI 결과를 DB 저장 없이 수정 폼에 임시 반영하는 구조 설계

✅ 체크리스트
 - [x] PR 대상 브랜치가 develop 인지 확인
 - [x] 커밋 컨벤션(Gitmoji + type + message) 준수
 - [x] 불필요한 로그/디버그 코드 제거
 - [x] 예외 처리 및 에러 코드 반영

👀 Review Rule (develop)
- develop 브랜치 PR은 리뷰 승인 2회 이상 필수
- 리뷰 코멘트 모두 해결 후 merge