### PR TITLE
refactor: JWT 인증 기반 Experience API 구조 개선

### DIFF
--- a/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceAttachmentController.java
+++ b/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceAttachmentController.java
@@ -1,49 +1,52 @@
 package com.moayo.moayobackend.experience.controller;
 
-import com.moayo.moayobackend.experience.service.ExperienceAttachmentService;
 import com.moayo.moayobackend.experience.dto.request.AttachFileRequest;
 import com.moayo.moayobackend.experience.dto.response.FileAttachmentResponse;
+import com.moayo.moayobackend.experience.service.ExperienceAttachmentService;
+import com.moayo.moayobackend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/experiences/{experienceId}/attachments/files")
+@RequestMapping("/api/experiences/{experienceId}/attachments/files")
 public class ExperienceAttachmentController {
 
     private final ExperienceAttachmentService attachmentService;
 
-    // 파일 첨부(연결) - fileId를 받아 experience에 연결
+    // 파일 첨부(연결)
     @PostMapping
-    public ResponseEntity<Void> attachFile(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    public ResponseEntity<ApiResponse<Void>> attachFile(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId,
             @RequestBody AttachFileRequest req
     ) {
-        attachmentService.attachFile(memberId, experienceId, req);
-        return ResponseEntity.noContent().build();
+        attachmentService.attachFile(userId, experienceId, req);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "파일 첨부 성공", null));
     }
 
-    // 첨부된 파일 목록 조회
+    // 첨부 파일 목록
     @GetMapping
-    public ResponseEntity<List<FileAttachmentResponse>> listFiles(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    public ResponseEntity<ApiResponse<List<FileAttachmentResponse>>> listFiles(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId
     ) {
-        return ResponseEntity.ok(attachmentService.listFiles(memberId, experienceId));
+        var result = attachmentService.listFiles(userId, experienceId);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "첨부 파일 목록 조회 성공", result));
     }
 
     // 첨부 파일 삭제(연결 해제)
     @DeleteMapping("/{fileId}")
-    public ResponseEntity<Void> detachFile(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    public ResponseEntity<ApiResponse<Void>> detachFile(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId,
             @PathVariable Long fileId
     ) {
-        attachmentService.detachFile(memberId, experienceId, fileId);
-        return ResponseEntity.noContent().build();
+        attachmentService.detachFile(userId, experienceId, fileId);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "첨부 파일 삭제 성공", null));
     }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceController.java
+++ b/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceController.java
@@ -1,100 +1,107 @@
 package com.moayo.moayobackend.experience.controller;
 
 import com.moayo.moayobackend.experience.dto.request.ExperienceAiDraftRequest;
-import com.moayo.moayobackend.experience.dto.response.ExperienceAiDraftResponse;
-import com.moayo.moayobackend.experience.service.ExperienceService;
 import com.moayo.moayobackend.experience.dto.request.ExperienceCreateRequest;
 import com.moayo.moayobackend.experience.dto.request.ExperienceUpdateRequest;
 import com.moayo.moayobackend.experience.dto.request.ExperienceVisibilityRequest;
+import com.moayo.moayobackend.experience.dto.response.ExperienceAiDraftResponse;
 import com.moayo.moayobackend.experience.dto.response.ExperienceDetailResponse;
 import com.moayo.moayobackend.experience.dto.response.ExperienceSummaryResponse;
+import com.moayo.moayobackend.experience.service.ExperienceService;
+import com.moayo.moayobackend.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/experiences")
 public class ExperienceController {
 
     private final ExperienceService experienceService;
 
-    // 내 이력 목록 조회 (카드 리스트)
-    @GetMapping("/experiences")
-    public ResponseEntity<List<ExperienceSummaryResponse>> listMyExperiences(
-            @RequestHeader("X-MEMBER-ID") Long memberId
+    // 1) 내 이력 목록
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<ExperienceSummaryResponse>>> myList(
+            @AuthenticationPrincipal Long userId
     ) {
-        return ResponseEntity.ok(experienceService.listMyExperiences(memberId));
+        var result = experienceService.listMyExperiences(userId);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "내 이력 목록 조회 성공", result));
     }
 
-    // 이력 생성 (이력 추가 페이지 등록하기)
-    @PostMapping("/experiences")
-    public ResponseEntity<Void> create(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
-            @RequestBody ExperienceCreateRequest req
-    ) {
-        Long id = experienceService.create(memberId, req);
-        return ResponseEntity.created(URI.create("/api/v1/experiences/" + id)).build();
-    }
-
-    // 이력 상세 조회 (카드 클릭 -> 팝업 열기)
-    @GetMapping("/experiences/{experienceId}")
-    public ResponseEntity<ExperienceDetailResponse> getDetail(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    // 2) 내 이력 상세
+    @GetMapping("/me/{experienceId}")
+    public ResponseEntity<ApiResponse<ExperienceDetailResponse>> myDetail(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId
     ) {
-        return ResponseEntity.ok(experienceService.getMyDetail(memberId, experienceId));
+        var result = experienceService.getMyDetail(userId, experienceId);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "내 이력 상세 조회 성공", result));
     }
 
-    // 이력 수정 저장 (수정 페이지 저장하기)
-    @PatchMapping("/experiences/{experienceId}")
-    public ResponseEntity<Void> update(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    // 3) 이력 생성
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> create(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ExperienceCreateRequest req
+    ) {
+        Long id = experienceService.create(userId, req);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "이력 생성 성공", id));
+    }
+
+    // 4) 이력 수정
+    @PatchMapping("/{experienceId}")
+    public ResponseEntity<ApiResponse<Void>> update(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId,
             @RequestBody ExperienceUpdateRequest req
     ) {
-        experienceService.update(memberId, experienceId, req);
-        return ResponseEntity.noContent().build();
+        experienceService.update(userId, experienceId, req);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "이력 수정 성공", null));
     }
 
-    // 이력 삭제 (팝업에서 삭제하기)
-    @DeleteMapping("/experiences/{experienceId}")
-    public ResponseEntity<Void> delete(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    // 5) 이력 삭제
+    @DeleteMapping("/{experienceId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId
     ) {
-        experienceService.delete(memberId, experienceId);
-        return ResponseEntity.noContent().build();
+        experienceService.delete(userId, experienceId);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "이력 삭제 성공", null));
     }
 
-    // 이력 공개/비공개 토글
-    @PatchMapping("/experiences/{experienceId}/visibility")
-    public ResponseEntity<Void> changeVisibility(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    // 6) 공개/비공개 변경
+    @PatchMapping("/{experienceId}/visibility")
+    public ResponseEntity<ApiResponse<Void>> changeVisibility(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId,
             @RequestBody ExperienceVisibilityRequest req
     ) {
-        experienceService.changeVisibility(memberId, experienceId, req);
-        return ResponseEntity.noContent().build();
+        experienceService.changeVisibility(userId, experienceId, req);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "공개 여부 변경 성공", null));
     }
 
-    // 타인 프로필: 공개 이력만 조회
-    @GetMapping("/users/{userId}/experiences")
-    public ResponseEntity<List<ExperienceSummaryResponse>> listPublicByUser(
-            @PathVariable Long userId
+    // 7) 타인 공개 이력 보기 (프로필 조회용)
+    @GetMapping("/public/{targetUserId}")
+    public ResponseEntity<ApiResponse<List<ExperienceSummaryResponse>>> publicList(
+            @PathVariable Long targetUserId
     ) {
-        return ResponseEntity.ok(experienceService.listPublicByUser(userId));
+        var result = experienceService.listPublicByUser(targetUserId);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "공개 이력 조회 성공", result));
     }
 
+    // 8) AI draft
     @PostMapping("/{experienceId}/ai/draft")
-    public ResponseEntity<ExperienceAiDraftResponse> draftWithAi(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    public ResponseEntity<ApiResponse<ExperienceAiDraftResponse>> draftWithAi(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId,
             @RequestBody(required = false) ExperienceAiDraftRequest req
     ) {
-        return ResponseEntity.ok(experienceService.draftWithAi(memberId, experienceId, req));
+        var result = experienceService.draftWithAi(userId, experienceId, req);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "AI draft 생성 성공", result));
     }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceLinkController.java
+++ b/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceLinkController.java
@@ -1,62 +1,65 @@
 package com.moayo.moayobackend.experience.controller;
 
-import com.moayo.moayobackend.experience.service.ExperienceLinkService;
 import com.moayo.moayobackend.experience.dto.request.ExperienceLinkCreateRequest;
 import com.moayo.moayobackend.experience.dto.request.ExperienceLinkUpdateRequest;
 import com.moayo.moayobackend.experience.dto.response.ExperienceLinkResponse;
+import com.moayo.moayobackend.experience.service.ExperienceLinkService;
+import com.moayo.moayobackend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/experiences/{experienceId}/attachments/links")
+@RequestMapping("/api/experiences/{experienceId}/attachments/links")
 public class ExperienceLinkController {
 
     private final ExperienceLinkService linkService;
 
     // 링크 추가
     @PostMapping
-    public ResponseEntity<Void> createLink(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    public ResponseEntity<ApiResponse<Void>> createLink(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId,
             @RequestBody ExperienceLinkCreateRequest req
     ) {
-        linkService.create(memberId, experienceId, req);
-        return ResponseEntity.noContent().build();
+        linkService.create(userId, experienceId, req);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "링크 추가 성공", null));
     }
 
-    // 링크 목록 조회
+    // 링크 목록
     @GetMapping
-    public ResponseEntity<List<ExperienceLinkResponse>> listLinks(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    public ResponseEntity<ApiResponse<List<ExperienceLinkResponse>>> listLinks(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId
     ) {
-        return ResponseEntity.ok(linkService.list(memberId, experienceId));
+        var result = linkService.list(userId, experienceId);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "링크 목록 조회 성공", result));
     }
 
     // 링크 수정
     @PatchMapping("/{linkId}")
-    public ResponseEntity<Void> updateLink(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    public ResponseEntity<ApiResponse<Void>> updateLink(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId,
             @PathVariable Long linkId,
             @RequestBody ExperienceLinkUpdateRequest req
     ) {
-        linkService.update(memberId, experienceId, linkId, req);
-        return ResponseEntity.noContent().build();
+        linkService.update(userId, experienceId, linkId, req);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "링크 수정 성공", null));
     }
 
     // 링크 삭제
     @DeleteMapping("/{linkId}")
-    public ResponseEntity<Void> deleteLink(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+    public ResponseEntity<ApiResponse<Void>> deleteLink(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long experienceId,
             @PathVariable Long linkId
     ) {
-        linkService.delete(memberId, experienceId, linkId);
-        return ResponseEntity.noContent().build();
+        linkService.delete(userId, experienceId, linkId);
+        return ResponseEntity.ok(ApiResponse.ok("SUCCESS-200", "링크 삭제 성공", null));
     }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/entity/Experience.java
+++ b/src/main/java/com/moayo/moayobackend/experience/entity/Experience.java
@@ -1,5 +1,6 @@
 package com.moayo.moayobackend.experience.entity;
 
+import com.moayo.moayobackend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,17 +13,19 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "experience")
-public class Experience {
+public class Experience extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long memberId;
+    // JWT에서 꺼낸 userId 저장
+    @Column(nullable = false)
+    private Long userId;
 
     private String organization; // 주최/기관
-    private String title; // 활동명
-    private String activity; // 참여형태/활동분류
-    private String role; // 역할
+    private String title;        // 활동명
+    private String activity;     // 참여형태/활동분류
+    private String role;         // 역할
 
     @Column(length = 2000)
     private String summary;      // 활동 소개
@@ -30,9 +33,10 @@ public class Experience {
     private LocalDate startDate;
     private LocalDate endDate;
 
+    @Column(nullable = false)
     private Boolean visible;
 
-    public Experience(Long memberId,
+    public Experience(Long userId,
                       String organization,
                       String title,
                       String activity,
@@ -41,7 +45,7 @@ public class Experience {
                       LocalDate startDate,
                       LocalDate endDate,
                       Boolean visible) {
-        this.memberId = memberId;
+        this.userId = userId;
         this.organization = organization;
         this.title = title;
         this.activity = activity;
@@ -52,8 +56,8 @@ public class Experience {
         this.visible = visible;
     }
 
-    public void validateOwner(Long memberId) {
-        if (this.memberId == null || !this.memberId.equals(memberId)) {
+    public void validateOwner(Long userId) {
+        if (this.userId == null || !this.userId.equals(userId)) {
             throw new IllegalArgumentException("No permission");
         }
     }
@@ -65,24 +69,16 @@ public class Experience {
                            String summary,
                            LocalDate startDate,
                            LocalDate endDate) {
-        if (organization != null)
-            this.organization = organization;
-        if (title != null)
-            this.title = title;
-        if (activity != null)
-            this.activity = activity;
-        if (role != null)
-            this.role = role;
-        if (summary != null)
-            this.summary = summary;
-        if (startDate != null)
-            this.startDate = startDate;
-        if (endDate != null)
-            this.endDate = endDate;
+        if (organization != null) this.organization = organization;
+        if (title != null) this.title = title;
+        if (activity != null) this.activity = activity;
+        if (role != null) this.role = role;
+        if (summary != null) this.summary = summary;
+        if (startDate != null) this.startDate = startDate;
+        if (endDate != null) this.endDate = endDate;
     }
 
     public void changeVisibility(Boolean visible) {
-        if (visible != null)
-            this.visible = visible;
+        if (visible != null) this.visible = visible;
     }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/entity/ExperienceFile.java
+++ b/src/main/java/com/moayo/moayobackend/experience/entity/ExperienceFile.java
@@ -1,5 +1,6 @@
 package com.moayo.moayobackend.experience.entity;
 
+import com.moayo.moayobackend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,19 +11,22 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "experience_file")
-public class ExperienceFile {
+public class ExperienceFile extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long experienceId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private Experience experience;
 
+    @Column(nullable = false)
     private Long fileId;
 
     private String fileName;
 
-    public ExperienceFile(Long experienceId, Long fileId, String fileName) {
-        this.experienceId = experienceId;
+    public ExperienceFile(Experience experience, Long fileId, String fileName) {
+        this.experience = experience;
         this.fileId = fileId;
         this.fileName = fileName;
     }

--- a/src/main/java/com/moayo/moayobackend/experience/entity/ExperienceLink.java
+++ b/src/main/java/com/moayo/moayobackend/experience/entity/ExperienceLink.java
@@ -1,5 +1,6 @@
 package com.moayo.moayobackend.experience.entity;
 
+import com.moayo.moayobackend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,28 +11,28 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "experience_link")
-public class ExperienceLink {
+public class ExperienceLink extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long experienceId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private Experience experience;
 
     private String title;
 
     @Column(length = 1000)
     private String url;
 
-    public ExperienceLink(Long experienceId, String title, String url) {
-        this.experienceId = experienceId;
+    public ExperienceLink(Experience experience, String title, String url) {
+        this.experience = experience;
         this.title = title;
         this.url = url;
     }
 
     public void update(String title, String url) {
-        if (title != null)
-            this.title = title;
-        if (url != null)
-            this.url = url;
+        if (title != null) this.title = title;
+        if (url != null) this.url = url;
     }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceFileRepository.java
+++ b/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceFileRepository.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 public interface ExperienceFileRepository extends JpaRepository<ExperienceFile, Long> {
 
-    List<ExperienceFile> findAllByExperienceIdOrderByIdDesc(Long experienceId);
+    List<ExperienceFile> findAllByExperience_IdOrderByCreatedAtDesc(Long experienceId);
 
-    void deleteByExperienceIdAndFileId(Long experienceId, Long fileId);
+    boolean existsByExperience_IdAndFileId(Long experienceId, Long fileId);
 
-    boolean existsByExperienceIdAndFileId(Long experienceId, Long fileId);
+    void deleteByExperience_IdAndFileId(Long experienceId, Long fileId);
 }

--- a/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceLinkRepository.java
+++ b/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceLinkRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface ExperienceLinkRepository extends JpaRepository<ExperienceLink, Long> {
 
-    List<ExperienceLink> findAllByExperienceIdOrderByIdDesc(Long experienceId);
+    List<ExperienceLink> findAllByExperience_IdOrderByCreatedAtDesc(Long experienceId);
 
-    Optional<ExperienceLink> findByIdAndExperienceId(Long id, Long experienceId);
+    Optional<ExperienceLink> findByIdAndExperience_Id(Long id, Long experienceId);
 }

--- a/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/moayo/moayobackend/experience/repository/ExperienceRepository.java
@@ -6,8 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
-
-    List<Experience> findAllByMemberIdOrderByIdDesc(Long memberId);
-
-    List<Experience> findAllByMemberIdAndVisibleTrueOrderByIdDesc(Long memberId);
+    List<Experience> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+    List<Experience> findAllByUserIdAndVisibleTrueOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/moayo/moayobackend/experience/service/ExperienceAttachmentService.java
+++ b/src/main/java/com/moayo/moayobackend/experience/service/ExperienceAttachmentService.java
@@ -1,9 +1,9 @@
 package com.moayo.moayobackend.experience.service;
 
 import com.moayo.moayobackend.experience.dto.request.AttachFileRequest;
+import com.moayo.moayobackend.experience.dto.response.FileAttachmentResponse;
 import com.moayo.moayobackend.experience.entity.Experience;
 import com.moayo.moayobackend.experience.entity.ExperienceFile;
-import com.moayo.moayobackend.experience.dto.response.FileAttachmentResponse;
 import com.moayo.moayobackend.experience.repository.ExperienceFileRepository;
 import com.moayo.moayobackend.experience.repository.ExperienceRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,36 +20,38 @@ public class ExperienceAttachmentService {
     private final ExperienceFileRepository fileRepository;
 
     @Transactional
-    public void attachFile(Long memberId, Long experienceId, AttachFileRequest req) {
+    public void attachFile(Long userId, Long experienceId, AttachFileRequest req) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
-        if (req.fileId() == null) throw new IllegalArgumentException("fileId is required");
+        if (req == null || req.fileId() == null) {
+            throw new IllegalArgumentException("fileId is required");
+        }
 
-        boolean exists = fileRepository.existsByExperienceIdAndFileId(experienceId, req.fileId());
-        if (exists) return; // 중복 첨부 방지(원하면 예외로 바꿔도 됨)
+        boolean exists = fileRepository.existsByExperience_IdAndFileId(experienceId, req.fileId());
+        if (exists) return;
 
-        fileRepository.save(new ExperienceFile(experienceId, req.fileId(), req.fileName()));
+        fileRepository.save(new ExperienceFile(e, req.fileId(), req.fileName()));
     }
 
     @Transactional(readOnly = true)
-    public List<FileAttachmentResponse> listFiles(Long memberId, Long experienceId) {
+    public List<FileAttachmentResponse> listFiles(Long userId, Long experienceId) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
-        return fileRepository.findAllByExperienceIdOrderByIdDesc(experienceId).stream()
+        return fileRepository.findAllByExperience_IdOrderByCreatedAtDesc(experienceId).stream()
                 .map(f -> new FileAttachmentResponse(f.getFileId(), f.getFileName()))
                 .toList();
     }
 
     @Transactional
-    public void detachFile(Long memberId, Long experienceId, Long fileId) {
+    public void detachFile(Long userId, Long experienceId, Long fileId) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
-        fileRepository.deleteByExperienceIdAndFileId(experienceId, fileId);
+        fileRepository.deleteByExperience_IdAndFileId(experienceId, fileId);
     }
 }

--- a/src/main/java/com/moayo/moayobackend/experience/service/ExperienceLinkService.java
+++ b/src/main/java/com/moayo/moayobackend/experience/service/ExperienceLinkService.java
@@ -1,10 +1,10 @@
 package com.moayo.moayobackend.experience.service;
 
-import com.moayo.moayobackend.experience.entity.Experience;
-import com.moayo.moayobackend.experience.entity.ExperienceLink;
 import com.moayo.moayobackend.experience.dto.request.ExperienceLinkCreateRequest;
 import com.moayo.moayobackend.experience.dto.request.ExperienceLinkUpdateRequest;
 import com.moayo.moayobackend.experience.dto.response.ExperienceLinkResponse;
+import com.moayo.moayobackend.experience.entity.Experience;
+import com.moayo.moayobackend.experience.entity.ExperienceLink;
 import com.moayo.moayobackend.experience.repository.ExperienceLinkRepository;
 import com.moayo.moayobackend.experience.repository.ExperienceRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,44 +21,44 @@ public class ExperienceLinkService {
     private final ExperienceLinkRepository linkRepository;
 
     @Transactional
-    public void create(Long memberId, Long experienceId, ExperienceLinkCreateRequest req) {
+    public void create(Long userId, Long experienceId, ExperienceLinkCreateRequest req) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
-        linkRepository.save(new ExperienceLink(experienceId, req.title(), req.url()));
+        linkRepository.save(new ExperienceLink(e, req.title(), req.url()));
     }
 
     @Transactional(readOnly = true)
-    public List<ExperienceLinkResponse> list(Long memberId, Long experienceId) {
+    public List<ExperienceLinkResponse> list(Long userId, Long experienceId) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
-        return linkRepository.findAllByExperienceIdOrderByIdDesc(experienceId).stream()
+        return linkRepository.findAllByExperience_IdOrderByCreatedAtDesc(experienceId).stream()
                 .map(l -> new ExperienceLinkResponse(l.getId(), l.getTitle(), l.getUrl()))
                 .toList();
     }
 
     @Transactional
-    public void update(Long memberId, Long experienceId, Long linkId, ExperienceLinkUpdateRequest req) {
+    public void update(Long userId, Long experienceId, Long linkId, ExperienceLinkUpdateRequest req) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
-        ExperienceLink link = linkRepository.findByIdAndExperienceId(linkId, experienceId)
+        ExperienceLink link = linkRepository.findByIdAndExperience_Id(linkId, experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Link not found"));
 
         link.update(req.title(), req.url());
     }
 
     @Transactional
-    public void delete(Long memberId, Long experienceId, Long linkId) {
+    public void delete(Long userId, Long experienceId, Long linkId) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
-        ExperienceLink link = linkRepository.findByIdAndExperienceId(linkId, experienceId)
+        ExperienceLink link = linkRepository.findByIdAndExperience_Id(linkId, experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Link not found"));
 
         linkRepository.delete(link);

--- a/src/main/java/com/moayo/moayobackend/experience/service/ExperienceService.java
+++ b/src/main/java/com/moayo/moayobackend/experience/service/ExperienceService.java
@@ -1,13 +1,13 @@
 package com.moayo.moayobackend.experience.service;
 
 import com.moayo.moayobackend.experience.dto.request.ExperienceAiDraftRequest;
-import com.moayo.moayobackend.experience.dto.response.ExperienceAiDraftResponse;
-import com.moayo.moayobackend.experience.entity.Experience;
 import com.moayo.moayobackend.experience.dto.request.ExperienceCreateRequest;
 import com.moayo.moayobackend.experience.dto.request.ExperienceUpdateRequest;
 import com.moayo.moayobackend.experience.dto.request.ExperienceVisibilityRequest;
+import com.moayo.moayobackend.experience.dto.response.ExperienceAiDraftResponse;
 import com.moayo.moayobackend.experience.dto.response.ExperienceDetailResponse;
 import com.moayo.moayobackend.experience.dto.response.ExperienceSummaryResponse;
+import com.moayo.moayobackend.experience.entity.Experience;
 import com.moayo.moayobackend.experience.repository.ExperienceFileRepository;
 import com.moayo.moayobackend.experience.repository.ExperienceLinkRepository;
 import com.moayo.moayobackend.experience.repository.ExperienceRepository;
@@ -27,8 +27,8 @@ public class ExperienceService {
     private final ExperienceLinkRepository experienceLinkRepository;
 
     @Transactional(readOnly = true)
-    public List<ExperienceSummaryResponse> listMyExperiences(Long memberId) {
-        return experienceRepository.findAllByMemberIdOrderByIdDesc(memberId).stream()
+    public List<ExperienceSummaryResponse> listMyExperiences(Long userId) {
+        return experienceRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
                 .map(e -> new ExperienceSummaryResponse(
                         e.getId(),
                         e.getOrganization(),
@@ -43,9 +43,9 @@ public class ExperienceService {
     }
 
     @Transactional
-    public Long create(Long memberId, ExperienceCreateRequest req) {
+    public Long create(Long userId, ExperienceCreateRequest req) {
         Experience e = new Experience(
-                memberId,
+                userId,
                 req.organization(),
                 req.title(),
                 req.activity(),
@@ -59,10 +59,10 @@ public class ExperienceService {
     }
 
     @Transactional(readOnly = true)
-    public ExperienceDetailResponse getMyDetail(Long memberId, Long experienceId) {
+    public ExperienceDetailResponse getMyDetail(Long userId, Long experienceId) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
         return new ExperienceDetailResponse(
                 e.getId(),
@@ -78,10 +78,10 @@ public class ExperienceService {
     }
 
     @Transactional
-    public void update(Long memberId, Long experienceId, ExperienceUpdateRequest req) {
+    public void update(Long userId, Long experienceId, ExperienceUpdateRequest req) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
         e.applyPatch(
                 req.organization(),
@@ -95,26 +95,27 @@ public class ExperienceService {
     }
 
     @Transactional
-    public void delete(Long memberId, Long experienceId) {
+    public void delete(Long userId, Long experienceId) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
-        experienceRepository.deleteById(experienceId);
+        experienceRepository.delete(e);
     }
 
     @Transactional
-    public void changeVisibility(Long memberId, Long experienceId, ExperienceVisibilityRequest req) {
+    public void changeVisibility(Long userId, Long experienceId, ExperienceVisibilityRequest req) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
         e.changeVisibility(req.visible());
     }
 
+    // 타인(프로필) 공개 이력 조회
     @Transactional(readOnly = true)
     public List<ExperienceSummaryResponse> listPublicByUser(Long userId) {
-        return experienceRepository.findAllByMemberIdAndVisibleTrueOrderByIdDesc(userId).stream()
+        return experienceRepository.findAllByUserIdAndVisibleTrueOrderByCreatedAtDesc(userId).stream()
                 .map(e -> new ExperienceSummaryResponse(
                         e.getId(),
                         e.getOrganization(),
@@ -129,14 +130,14 @@ public class ExperienceService {
     }
 
     @Transactional(readOnly = true)
-    public ExperienceAiDraftResponse draftWithAi(Long memberId, Long experienceId, ExperienceAiDraftRequest req) {
+    public ExperienceAiDraftResponse draftWithAi(Long userId, Long experienceId, ExperienceAiDraftRequest req) {
         Experience e = experienceRepository.findById(experienceId)
                 .orElseThrow(() -> new IllegalArgumentException("Experience not found"));
-        e.validateOwner(memberId);
+        e.validateOwner(userId);
 
         // 첨부파일, 링크를 context로 합쳐 AI 품질 올리기
-        var files = experienceFileRepository.findAllByExperienceIdOrderByIdDesc(experienceId);
-        var links = experienceLinkRepository.findAllByExperienceIdOrderByIdDesc(experienceId);
+        var files = experienceFileRepository.findAllByExperience_IdOrderByCreatedAtDesc(experienceId);
+        var links = experienceLinkRepository.findAllByExperience_IdOrderByCreatedAtDesc(experienceId);
 
         String context = buildContext(e, files, links);
         String prompt = (req == null || req.prompt() == null) ? "" : req.prompt();


### PR DESCRIPTION
## ✅ 작업 요약
- 이력서(Experience) 도메인 전반을 JWT 기반 인증 방식으로 통일

## 🔗 관련 이슈
- Closes #49 

## 🧩 주요 변경 사항
- @RequestHeader("X-MEMBER-ID") 제거
- 모든 Experience API에서 @AuthenticationPrincipal Long userId 사용
- 사용자 식별 로직을 JWT 토큰 기반으로 통일
- memberId → userId 전면 변경
- Experience, ExperienceFile, ExperienceLink에 BaseEntity 상속
- createdAt, updatedAt Auditing 필드 적용
- @EnableJpaAuditing 활성화
- Controller 응답을 ApiResponse<T> 기반으로 통합

## ✅ 체크리스트
- [x] PR 대상 브랜치가 `develop` 인지 확인
- [x] 커밋 컨벤션(Gitmoji + type + message) 준수
- [x] 불필요한 로그/디버그 코드 제거
- [ ] 예외 처리 및 에러 코드 반영

---

### 👀 Review Rule (develop)
- develop 브랜치 PR은 **리뷰 승인 2회 이상 필수**
- 리뷰 코멘트 모두 해결 후 merge
