### PR TITLE
feat: 채팅 API 작업 1차 완료 

### DIFF
--- a/src/main/java/com/moayo/moayobackend/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/moayo/moayobackend/chat/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.moayo.moayobackend.chat.controller;
 
 import com.moayo.moayobackend.chat.dto.request.CreateChatRoomRequest;
+import com.moayo.moayobackend.chat.dto.response.ChatRoomListItemResponse;
 import com.moayo.moayobackend.chat.dto.response.CreateChatRoomResponse;
 import com.moayo.moayobackend.chat.service.ChatRoomService;
 import com.moayo.moayobackend.global.response.ApiResponse;
@@ -9,10 +10,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @Tag(name = "채팅방", description = "채팅방 생성 및 조회 관련 API")
@@ -39,6 +39,33 @@ public class ChatRoomController {
                 ApiResponse.ok( "CHAT200_1",
                         "채팅방 생성 또는 조회에 성공했습니다.",
                         new CreateChatRoomResponse(roomId))
+        );
+    }
+
+    @Operation(summary = "내 채팅방 목록 조회", description = "JWT 인증된 사용자 기준으로, 내가 참여중인 채팅방 목록을 최신순으로 조회합니다.")
+    @GetMapping("/rooms")
+    public ApiResponse<List<ChatRoomListItemResponse>> getMyChatRooms(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<ChatRoomListItemResponse> result = chatRoomService.getMyChatRooms(userId);
+        return ApiResponse.ok(
+                "CHAT200_2",
+                "채팅방 목록 조회에 성공했습니다.",
+                result
+        );
+    }
+
+    @Operation(summary = "채팅방 읽음 처리", description = "해당 채팅방의 마지막 메시지까지 읽음 처리합니다.")
+    @PatchMapping("/rooms/{roomId}/read")
+    public ApiResponse<Void> readChatRoom(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long roomId
+    ) {
+        chatRoomService.readChatRoom(roomId, userId);
+        return ApiResponse.ok(
+                "CHAT200_3",
+                "채팅방 읽음 처리에 성공했습니다.",
+                null
         );
     }
 }

--- a/src/main/java/com/moayo/moayobackend/chat/dto/response/ChatRoomListItemResponse.java
+++ b/src/main/java/com/moayo/moayobackend/chat/dto/response/ChatRoomListItemResponse.java
@@ -1,0 +1,12 @@
+package com.moayo.moayobackend.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomListItemResponse(
+        Long roomId,
+        Long opponentUserId,
+        String opponentImageUrl,
+        String lastMessageContent,
+        LocalDateTime lastMessageCreatedAt,
+        boolean hasUnread
+) {}

--- a/src/main/java/com/moayo/moayobackend/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/moayo/moayobackend/chat/repository/ChatParticipantRepository.java
@@ -1,8 +1,70 @@
 package com.moayo.moayobackend.chat.repository;
 
 import com.moayo.moayobackend.chat.entity.ChatParticipant;
+import com.moayo.moayobackend.chat.repository.projection.ChatRoomListItemProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
     boolean existsByChatRoomIdAndUserId(Long chatRoomId, Long userId);
+
+    @Query(value = """
+	SELECT
+	    cp.chat_room_id AS roomId,
+	    other.user_id   AS opponentUserId,
+	    pr.image_url    AS opponentImageUrl,
+	    m.content       AS lastMessageContent,
+	    m.created_at    AS lastMessageCreatedAt,
+	    CASE
+	        WHEN EXISTS (
+	            SELECT 1
+	            FROM message m3
+	            WHERE m3.chat_room_id = cp.chat_room_id
+	              AND m3.sender_id <> :userId
+	              AND (
+	                   cp.last_message_id IS NULL
+	                   OR m3.id > cp.last_message_id
+	              )
+	        )
+	        THEN TRUE
+	        ELSE FALSE
+	    END AS hasUnread
+	FROM chat_participants cp
+	JOIN chat_participants other
+	    ON cp.chat_room_id = other.chat_room_id
+	    AND other.user_id <> :userId
+	LEFT JOIN profiles pr
+	    ON pr.user_id = other.user_id
+	LEFT JOIN message m
+	    ON m.id = (
+	        SELECT m2.id
+	        FROM message m2
+	        WHERE m2.chat_room_id = cp.chat_room_id
+	        ORDER BY m2.created_at DESC
+	        LIMIT 1
+	    )
+	WHERE cp.user_id = :userId
+	ORDER BY m.created_at DESC, cp.chat_room_id DESC	
+	""", nativeQuery = true)
+    List<ChatRoomListItemProjection> findChatRoomListByUserId(
+            @Param("userId") Long userId
+    );
+
+	@Modifying
+	@Query("""
+		UPDATE ChatParticipant cp
+		SET cp.lastMessageId = :messageId
+		WHERE cp.chatRoomId = :roomId
+		  AND cp.userId = :userId
+	""")
+	int updateLastReadMessage(
+			@Param("roomId") Long roomId,
+			@Param("userId") Long userId,
+			@Param("messageId") Long messageId
+	);
+
 }

--- a/src/main/java/com/moayo/moayobackend/chat/repository/MessageRepository.java
+++ b/src/main/java/com/moayo/moayobackend/chat/repository/MessageRepository.java
@@ -2,9 +2,19 @@ package com.moayo.moayobackend.chat.repository;
 
 import com.moayo.moayobackend.chat.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
+
+    @Query("""
+		SELECT m.id
+		FROM Message m
+		WHERE m.chatRoomId = :roomId
+		ORDER BY m.createdAt DESC
+	""")
+    List<Long> findLastMessageIdsByRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/moayo/moayobackend/chat/repository/projection/ChatRoomListItemProjection.java
+++ b/src/main/java/com/moayo/moayobackend/chat/repository/projection/ChatRoomListItemProjection.java
@@ -1,0 +1,12 @@
+package com.moayo.moayobackend.chat.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface ChatRoomListItemProjection {
+    Long getRoomId();
+    Long getOpponentUserId();
+    String getOpponentImageUrl();
+    String getLastMessageContent();
+    LocalDateTime getLastMessageCreatedAt();
+    Integer getHasUnread();
+}

--- a/src/main/java/com/moayo/moayobackend/chat/service/ChatRoomService.java
+++ b/src/main/java/com/moayo/moayobackend/chat/service/ChatRoomService.java
@@ -1,16 +1,21 @@
 package com.moayo.moayobackend.chat.service;
 
+import com.moayo.moayobackend.chat.dto.response.ChatRoomListItemResponse;
 import com.moayo.moayobackend.chat.entity.ChatParticipant;
 import com.moayo.moayobackend.chat.entity.ChatRoom;
 import com.moayo.moayobackend.chat.exception.ChatException;
 import com.moayo.moayobackend.chat.exception.code.ChatErrorCode;
 import com.moayo.moayobackend.chat.repository.ChatParticipantRepository;
 import com.moayo.moayobackend.chat.repository.ChatRoomRepository;
+import com.moayo.moayobackend.chat.repository.MessageRepository;
+import com.moayo.moayobackend.chat.repository.projection.ChatRoomListItemProjection;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +23,7 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatParticipantRepository chatParticipantRepository;
+    private final MessageRepository messageRepository;
 
     @Transactional // user A와 user B 사이의 채팅방 id 반환 (없으면 방을 생성해 반환)
     public Long getOrCreateRoom(Long userAId, Long userBId, Long originPostId) {
@@ -79,5 +85,61 @@ public class ChatRoomService {
                     ChatErrorCode.CHAT_ROOM_CREATE_CONFLICT
             );
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomListItemResponse> getMyChatRooms(Long userId) {
+        if (userId == null) {
+            throw new ChatException(ChatErrorCode.CHAT_USER_ID_REQUIRED);
+        }
+
+        List<ChatRoomListItemProjection> rows =
+                chatParticipantRepository.findChatRoomListByUserId(userId);
+
+        return rows.stream()
+                .map(row -> {
+                    Integer unreadRaw = row.getHasUnread(); // 0 또는 1 또는 null
+                    boolean hasUnread = (unreadRaw != null && unreadRaw == 1);
+
+                    return new ChatRoomListItemResponse(
+                            row.getRoomId(),
+                            row.getOpponentUserId(),
+                            row.getOpponentImageUrl(),
+                            row.getLastMessageContent(),
+                            row.getLastMessageCreatedAt(),
+                            hasUnread
+                    );
+                })
+                .toList();
+    }
+
+    @Transactional
+    public void readChatRoom(Long roomId, Long userId) {
+        if (userId == null) {
+            throw new ChatException(ChatErrorCode.CHAT_USER_ID_REQUIRED);
+        }
+
+        // 이 유저가 이 방 참가자인지
+        boolean isParticipant = chatParticipantRepository.existsByChatRoomIdAndUserId(roomId, userId);
+        if (!isParticipant) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_FORBIDDEN);
+        }
+
+        // 이 방의 마지막 메시지 ID 조회
+        var ids = messageRepository.findLastMessageIdsByRoomId(roomId);
+
+        // 메시지가 하나도 없으면 읽음 처리할 게 없으니 그냥 리턴
+        if (ids.isEmpty()) {
+            return;
+        }
+
+        Long lastMessageId = ids.get(0);
+
+        // 3. 내 참가자 row의 lastMessageId 업데이트
+        chatParticipantRepository.updateLastReadMessage(
+                roomId,
+                userId,
+                lastMessageId
+        );
     }
 }


### PR DESCRIPTION
## ✅ 작업 요약
- 채팅 도메인 1순위 작업 완료 (세부 개선 예정)
## 🔗 관련 이슈
- Closes #44

## 🧩 주요 변경 사항
1. 채팅방 목록 조회 API
📌 기능 개요
- JWT 인증된 사용자를 기준으로 참여 중인 채팅방 목록 제공
- 채팅방 별 상대 유저 정보, 마지막 메시지, 읽음 상태(hasUnread)를 포함한 요약 정보 반환

✅ 처리 로직
- JWT 인증을 통해 사용자 식별
- 사용자 참여 채팅방 조회 및 참가자 정보 기반 상대 유저 매핑
- 채팅방 별 마지막 메시지 조회를 통해 대화 상태 구성
- 참가자 last_message_id를 활용한 안 읽음 여부 계산
- 최신 메시지 기준 내림차순 정렬로 UX 개선

2. 채팅방 읽음 처리 API
📌 기능 개요
- 사용자의 채팅방 진입을 기준으로 읽음 상태를 반영

✅ 처리 로직
- JWT 인증 사용자 기준으로 채팅방 참가 여부 검증
- 해당 채팅방의 가장 최신 메세지 ID 조회
- 참가자 정보(ChatParticipant)의 last_message_id를 최신 메시지 ID로 업데이트하여 읽음 상태 동기화

🔐 인증 / 인가
- 모든 API는 JWT 인증이 완료된 사용자만 접근 가능

**읽음 처리 API는 프론트에서 Optimistic UI 방식 사용을 지향**

## ✅ 체크리스트
- [x] PR 대상 브랜치가 `develop` 인지 확인
- [x] 커밋 컨벤션(Gitmoji + type + message) 준수
- [x] 불필요한 로그/디버그 코드 제거
- [x] 예외 처리 및 에러 코드 반영

---

### 👀 Review Rule (develop)
- develop 브랜치 PR은 **리뷰 승인 2회 이상 필수**
- 리뷰 코멘트 모두 해결 후 merge
