### PR TITLE
[Bug] login option관련 403 에러 

### DIFF
--- a/src/main/java/com/moayo/moayobackend/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/com/moayo/moayobackend/auth/filter/JwtAuthFilter.java
@@ -31,8 +31,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         String header = request.getHeader("Authorization");
         System.out.println(">>> Swagger에서 넘어온 Header: [" + header + "]");
+        System.out.println(">>> 요청 api : [" + request.getMethod() + "] " + request.getRequestURI() + " | Header: [" + header + "]");
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring(7);
 

--- a/src/main/java/com/moayo/moayobackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/moayo/moayobackend/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 }))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                               "/api/v1/auth/**",      // 소셜 로그인 시작, 콜백, 토큰 재발급 등
                                 "/swagger-ui/**",       // 스웨거 UI


### PR DESCRIPTION
## ✅ 작업 요약
- CORS 및 OPTIONS 요청 처리 로직 개선: 프론트엔드 연동 시 발생하는 403 Forbidden 에러 해결

## 🔗 관련 이슈
- Closes #73 

## 🧩 주요 변경 사항
- SecurityConfig 수정:
  - HttpMethod.OPTIONS에 대한 permitAll() 설정 추가 (Preflight 에러 방지)
  - CORS AllowedOrigins에 프론트엔드 로컬(5173) 및 배포 주소 명시

- JwtAuthFilter 수정:
  - 필터 최상단에 OPTIONS 메서드 조기 통과(Return) 로직 추가
  - API 요청 로그에 Method와 URI 정보 추가하여 디버깅 편의성 증대

- DB(RDS) 관련:
  - users 테이블에 권한 체크를 위한 role 컬럼 대응 (SQL ALTER TABLE 필요)

## ✅ 체크리스트
- [x] PR 대상 브랜치가 `develop` 인지 확인
- [x] 커밋 컨벤션(Gitmoji + type + message) 준수
- [x] 불필요한 로그/디버그 코드 제거
- [ ] 예외 처리 및 에러 코드 반영

---

### 👀 Review Rule (develop)
- develop 브랜치 PR은 **리뷰 승인 2회 이상 필수**
- 리뷰 코멘트 모두 해결 후 merge
