### PR TITLE
[fix] 재로그인 시 기존 구글 유저 정보가 수정한 유저 정보에 덮어씌워지는 문제 해결

### DIFF
--- a/src/main/java/com/moayo/moayobackend/auth/service/GoogleOAuthService.java
+++ b/src/main/java/com/moayo/moayobackend/auth/service/GoogleOAuthService.java
@@ -92,10 +92,6 @@ public class GoogleOAuthService {
     @Transactional
     public User upsertGoogleUser(GoogleUserInfoResponseDto info) {
         return userRepository.findByOauthProviderAndOauthSub("google", info.sub())
-                .map(u -> {
-                    u.updateFromGoogle(info.email(), info.name());
-                    return u;
-                })
                 .orElseGet(() -> userRepository.save(
                         User.createGoogleUser(info.sub(), info.email(), info.name())
                 ));


### PR DESCRIPTION
## ✅ 작업 요약
- 재로그인 시 기존 구글 유저 정보가 수정한 유저 정보에 덮어씌워지는 문제 해결

## 🔗 관련 이슈
- Closes #97 

## 🧩 주요 변경 사항
- upsert 함수에서 map제거해 자동 업데이트 기능 삭제 

## ✅ 체크리스트
- [x] PR 대상 브랜치가 `develop` 인지 확인
- [x] 커밋 컨벤션(Gitmoji + type + message) 준수
- [x] 불필요한 로그/디버그 코드 제거
- [x] 예외 처리 및 에러 코드 반영

---

### 👀 Review Rule (develop)
- develop 브랜치 PR은 **리뷰 승인 2회 이상 필수**
- 리뷰 코멘트 모두 해결 후 merge
