### PR TITLE
refactor: 채팅 메시지 createdAt 시간 포맷 통일

### DIFF
--- a/src/main/java/com/moayo/moayobackend/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/moayo/moayobackend/chat/dto/response/ChatMessageResponse.java
@@ -4,6 +4,8 @@ import com.moayo.moayobackend.chat.entity.Message;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 
 @Getter
 @NoArgsConstructor
@@ -14,15 +16,22 @@ public class ChatMessageResponse {
     private Long chatRoomId;
     private Long senderId;
     private String content;
-    private LocalDateTime createdAt;
+    private String createdAt;
 
     public static ChatMessageResponse from(Message message) {
+        String createdAtIso = message.getCreatedAt()
+                .truncatedTo(ChronoUnit.MILLIS)                    // 2026-02-03T15:07:18.214
+                .atZone(ZoneId.of("UTC"))                 // 서버 타임존 적용 (보통 UTC)
+                .toInstant()                                       // UTC 기준 Instant
+                .toString();                                       // 2026-02-03T06:07:18.214Z
+
+
         return ChatMessageResponse.builder()
                 .id(message.getId())
                 .chatRoomId(message.getChatRoomId())
                 .senderId(message.getSenderId())
                 .content(message.getContent())
-                .createdAt(message.getCreatedAt())
+                .createdAt(createdAtIso)
                 .build();
     }
 }


### PR DESCRIPTION
## ✅ 작업 요약
- 채팅 메세지 응답DTO에서 createdAt 시간 포맷을 UTC 기준 ISO 8601 형식으로 통일
- fetchHistory 및 실시간(STOMP) 메시지 간 시간 표시 불일치(9시간 차이) 문제 해결

## 🔗 관련 이슈
- Closes #105

## 🧩 주요 변경 사항
- `ChatMessageResponse`의 `createdAt` 타입 변경
  - `LocalDateTime` → `String`
- 메시지 생성 시각을 UTC 기준 ISO 8601(`...Z`) 문자열로 변환하여 응답
- 마이크로초 단위 제거 후 밀리초 단위로 통일
- DB 스키마 및 `BaseEntity` 구조 변경 없음

## ✅ 체크리스트
- [ ] PR 대상 브랜치가 `develop` 인지 확인
- [ ] 커밋 컨벤션(Gitmoji + type + message) 준수
- [ ] 불필요한 로그/디버그 코드 제거
- [ ] 예외 처리 및 에러 코드 반영

---

### 👀 Review Rule (develop)
- develop 브랜치 PR은 **리뷰 승인 2회 이상 필수**
- 리뷰 코멘트 모두 해결 후 merge
