### PR TITLE
Feat: 채팅방 생성에서 postId 제거

### DIFF
--- a/src/main/java/com/moayo/moayobackend/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/moayo/moayobackend/chat/controller/ChatRoomController.java
@@ -31,8 +31,7 @@ public class ChatRoomController {
     ) {
         Long roomId = chatRoomService.getOrCreateRoom(
                 userId,
-                request.getUserBId(),
-                request.getOriginPostId()
+                request.getUserBId()
         );
 
         return ResponseEntity.ok(

--- a/src/main/java/com/moayo/moayobackend/chat/dto/request/CreateChatRoomRequest.java
+++ b/src/main/java/com/moayo/moayobackend/chat/dto/request/CreateChatRoomRequest.java
@@ -7,5 +7,4 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreateChatRoomRequest {
     private Long userBId;
-    private Long originPostId;
 }

--- a/src/main/java/com/moayo/moayobackend/chat/entity/ChatRoom.java
+++ b/src/main/java/com/moayo/moayobackend/chat/entity/ChatRoom.java
@@ -16,22 +16,12 @@ import lombok.*;
                         name = "uk_chat_rooms_room_key",
                         columnNames = {"room_key"}
                 )
-        },
-        indexes = {
-                @Index(
-                        name = "idx_chat_rooms_origin_post_id",
-                        columnList = "origin_post_id"
-                )
         }
 )
 public class ChatRoom extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    // 방이 처음 만들어질 때 기준이 된 게시글
-    @Column(name = "origin_post_id")
-    private Long originPostId;
 
     // 두 유저 조합(정렬된) 기준 고유 키
     @Column(name = "room_key", nullable = false, length = 100)

--- a/src/main/java/com/moayo/moayobackend/chat/exception/code/ChatErrorCode.java
+++ b/src/main/java/com/moayo/moayobackend/chat/exception/code/ChatErrorCode.java
@@ -12,7 +12,6 @@ public enum ChatErrorCode implements BaseErrorCode {
     // 400 BAD REQUEST
     CHAT_USER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CHAT_ROOM400_1", "채팅 참여자 ID가 필요합니다."),
     CHAT_CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "CHAT_ROOM400_2", "자기 자신과는 채팅을 생성할 수 없습니다."),
-    CHAT_ORIGIN_POST_ID_REQUIRED(HttpStatus.BAD_REQUEST, "CHAT_ROOM400_3", "채팅 생성 시 기준 게시글 ID가 필요합니다."),
 
     // 403 FORBIDDEN
     CHAT_ROOM_FORBIDDEN(

--- a/src/main/java/com/moayo/moayobackend/chat/service/ChatRoomService.java
+++ b/src/main/java/com/moayo/moayobackend/chat/service/ChatRoomService.java
@@ -26,7 +26,7 @@ public class ChatRoomService {
     private final MessageRepository messageRepository;
 
     @Transactional // user A와 user B 사이의 채팅방 id 반환 (없으면 방을 생성해 반환)
-    public Long getOrCreateRoom(Long userAId, Long userBId, Long originPostId) {
+    public Long getOrCreateRoom(Long userAId, Long userBId) {
 
         if (userAId == null || userBId == null) { // 둘의 id 검증
             throw new ChatException(ChatErrorCode.CHAT_USER_ID_REQUIRED);
@@ -36,9 +36,6 @@ public class ChatRoomService {
             throw new ChatException(ChatErrorCode.CHAT_CANNOT_CHAT_WITH_SELF);
         }
 
-        if (originPostId == null) { // 채팅을 시작한 게시글
-            throw new ChatException(ChatErrorCode.CHAT_ORIGIN_POST_ID_REQUIRED);
-        }
         // user A와 user B에 대한 채팅방이 있는지 검증 (room_key 이용)
         Long small = Math.min(userAId, userBId);
         Long big = Math.max(userAId, userBId);
@@ -46,13 +43,12 @@ public class ChatRoomService {
 
         return chatRoomRepository.findByRoomKey(roomKey)
                 .map(ChatRoom::getId)
-                .orElseGet(() -> createRoom(roomKey, originPostId, userAId, userBId));
+                .orElseGet(() -> createRoom(roomKey, userAId, userBId));
     }
 
     // 채팅방 생성
     private Long createRoom(
             String roomKey,
-            Long originPostId,
             Long userAId,
             Long userBId
     ) {
@@ -60,7 +56,6 @@ public class ChatRoomService {
             ChatRoom room = chatRoomRepository.save(
                     ChatRoom.builder()
                             .roomKey(roomKey)
-                            .originPostId(originPostId)
                             .build()
             );
 


### PR DESCRIPTION
## ✅ 작업 요약
- 채팅방 생성(조회) API에서 postId 제거

## 🔗 관련 이슈
- Closes #

## 🧩 주요 변경 사항
- 채팅방 엔티티에서 postId 부분 제거(인덱스 및 필드 모두 제거) 
- 채팅방 생성(조회) request에서 originPostId 제거
- 채팅방 생성(조회) controller/service에서 originPostId 검증 로직 부분 제거   

## ✅ 체크리스트
- [ ] PR 대상 브랜치가 `develop` 인지 확인
- [ ] 커밋 컨벤션(Gitmoji + type + message) 준수
- [ ] 불필요한 로그/디버그 코드 제거
- [ ] 예외 처리 및 에러 코드 반영

---

### 👀 Review Rule (develop)
- develop 브랜치 PR은 **리뷰 승인 2회 이상 필수**
- 리뷰 코멘트 모두 해결 후 merge
