### PR TITLE
fix: 공개 이력서 조회 API 경로 분리

### DIFF
--- a/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceController.java
+++ b/src/main/java/com/moayo/moayobackend/experience/controller/ExperienceController.java
@@ -110,17 +110,6 @@ public class ExperienceController {
         );
     }
 
-    @Operation(summary = "특정 사용자의 공개 이력서 조회", description = "특정 사용자가 공개 설정한 이력서 목록을 조회합니다.")
-    @GetMapping("/public/{targetUserId}")
-    public ResponseEntity<ApiResponse<List<ExperienceSummaryResponse>>> publicList(
-            @PathVariable Long targetUserId
-    ) {
-        var result = experienceService.listPublicByUser(targetUserId);
-        return ResponseEntity.ok(
-                ApiResponse.ok("SUCCESS-200", "공개 이력 조회 성공", result)
-        );
-    }
-
     @Operation(summary = "AI 기반 이력서 문구 초안 생성", description = "선택한 이력서 항목과 첨부 정보를 기반으로 AI가 이력서 문구 초안을 생성합니다.")
     @PostMapping("/{experienceId}/ai/draft")
     public ResponseEntity<ApiResponse<ExperienceAiDraftResponse>> draftWithAi(

--- a/src/main/java/com/moayo/moayobackend/experience/controller/UserPublicExperienceController.java
+++ b/src/main/java/com/moayo/moayobackend/experience/controller/UserPublicExperienceController.java
@@ -1,0 +1,32 @@
+package com.moayo.moayobackend.experience.controller;
+
+import com.moayo.moayobackend.experience.dto.response.ExperienceSummaryResponse;
+import com.moayo.moayobackend.experience.service.ExperienceService;
+import com.moayo.moayobackend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "공개 이력서 조회", description = "특정 사용자의 공개 이력서 목록 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserPublicExperienceController {
+
+    private final ExperienceService experienceService;
+
+    @Operation(summary = "특정 사용자의 공개 이력서 목록 조회", description = "특정 사용자가 공개 설정한 이력서 목록(visible=true)을 조회합니다.")
+    @GetMapping("/{userId}/experiences")
+    public ResponseEntity<ApiResponse<List<ExperienceSummaryResponse>>> publicList(
+            @PathVariable Long userId
+    ) {
+        var result = experienceService.listPublicByUser(userId);
+        return ResponseEntity.ok(
+                ApiResponse.ok("SUCCESS-200", "공개 이력 조회 성공", result)
+        );
+    }
+}


### PR DESCRIPTION
## ✅ 작업 요약
- 공개 이력서 조회 API 경로를 명확히 분리하여 Swagger/네트워크 충돌 해결
- 공개 조회 시 owner 검증 제거, visible=true 기준으로 조회하도록 수정
- 공개 첨부(파일/링크) 조회 API 정상 동작 보장

## 🔗 관련 이슈
- Closes #131 

## 🧩 주요 변경 사항
- 공개 상세 조회 API 분리 (/experiences/public/{experienceId})
- 공개 이력서 목록 조회 (/users/{userId}/experiences)
- 공개 첨부 조회 API에서 권한 체크 로직 정리
- Swagger 기준 API 역할 명확화

## ✅ 체크리스트
- [ ] PR 대상 브랜치가 `develop` 인지 확인
- [ ] 커밋 컨벤션(Gitmoji + type + message) 준수
- [ ] 불필요한 로그/디버그 코드 제거
- [ ] 예외 처리 및 에러 코드 반영

---

### 👀 Review Rule (develop)
- develop 브랜치 PR은 **리뷰 승인 2회 이상 필수**
- 리뷰 코멘트 모두 해결 후 merge
