### PR TITLE
refactor: 채팅방 목록 업데이트 구조 개선

### DIFF
--- a/src/main/java/com/moayo/moayobackend/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/moayo/moayobackend/chat/repository/ChatParticipantRepository.java
@@ -8,10 +8,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
     boolean existsByChatRoomIdAndUserId(Long chatRoomId, Long userId);
-
+	Optional<ChatParticipant> findFirstByChatRoomIdAndUserIdNot(Long chatRoomId, Long userId);
     @Query(value = """
 	SELECT
 	    cp.chat_room_id AS roomId,
@@ -66,5 +67,50 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 			@Param("userId") Long userId,
 			@Param("messageId") Long messageId
 	);
+
+	@Query(value = """
+	SELECT
+	    cp.chat_room_id AS roomId,
+	    other.user_id   AS opponentUserId,
+	    pr.image_url    AS opponentImageUrl,
+	    m.content       AS lastMessageContent,
+	    m.created_at    AS lastMessageCreatedAt,
+	    CASE
+	        WHEN EXISTS (
+	            SELECT 1
+	            FROM message m3
+	            WHERE m3.chat_room_id = cp.chat_room_id
+	              AND m3.sender_id <> :userId
+	              AND (
+	                   cp.last_message_id IS NULL
+	                   OR m3.id > cp.last_message_id
+	              )
+	        )
+	        THEN 1
+	        ELSE 0
+	    END AS hasUnread
+	FROM chat_participants cp
+	JOIN chat_participants other
+	    ON cp.chat_room_id = other.chat_room_id
+	    AND other.user_id <> :userId
+	LEFT JOIN profiles pr
+	    ON pr.user_id = other.user_id
+	LEFT JOIN message m
+	    ON m.id = (
+	        SELECT m2.id
+	        FROM message m2
+	        WHERE m2.chat_room_id = cp.chat_room_id
+	        ORDER BY m2.created_at DESC
+	        LIMIT 1
+	    )
+	WHERE cp.user_id = :userId
+	  AND cp.chat_room_id = :roomId
+	LIMIT 1
+	""", nativeQuery = true)
+	Optional<ChatRoomListItemProjection> findChatRoomListItemByUserIdAndRoomId(
+			@Param("userId") Long userId,
+			@Param("roomId") Long roomId
+	);
+
 
 }

--- a/src/main/java/com/moayo/moayobackend/chat/service/ChatMessageService.java
+++ b/src/main/java/com/moayo/moayobackend/chat/service/ChatMessageService.java
@@ -2,12 +2,15 @@ package com.moayo.moayobackend.chat.service;
 
 import com.moayo.moayobackend.chat.dto.request.ChatMessageRequest;
 import com.moayo.moayobackend.chat.dto.response.ChatMessageResponse;
+import com.moayo.moayobackend.chat.dto.response.ChatRoomListItemResponse;
 import com.moayo.moayobackend.chat.entity.Message;
 import com.moayo.moayobackend.chat.exception.ChatException;
 import com.moayo.moayobackend.chat.exception.code.ChatErrorCode;
 import com.moayo.moayobackend.chat.repository.ChatParticipantRepository;
 import com.moayo.moayobackend.chat.repository.ChatRoomRepository;
 import com.moayo.moayobackend.chat.repository.MessageRepository;
+import com.moayo.moayobackend.chat.repository.projection.ChatRoomListItemProjection;
+import com.moayo.moayobackend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,19 +26,20 @@ public class ChatMessageService {
     private final ChatParticipantRepository chatParticipantRepository;
     private final MessageRepository messageRepository;
 
+    private final ChatRoomListPushService chatRoomListPushService;
+    private final UserRepository userRepository;
+
     @Transactional
     public ChatMessageResponse sendMessage(Long chatRoomId, Long userId, ChatMessageRequest request) {
-        // 내용이 비었는지 체크
+
         if (!StringUtils.hasText(request.getContent())){
             throw new ChatException(ChatErrorCode.MESSAGE_CONTENT_EMPTY);
         }
 
-        // 방 존재 여부 체크
         if (!chatRoomRepository.existsById(chatRoomId)) {
             throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
         }
 
-        // 참가자인지 체크
         boolean isParticipant =
                 chatParticipantRepository.existsByChatRoomIdAndUserId(chatRoomId, userId);
 
@@ -43,18 +47,59 @@ public class ChatMessageService {
             throw new ChatException(ChatErrorCode.CHAT_ROOM_FORBIDDEN);
         }
 
-        // 메세지 생성
         Message message = Message.builder()
                 .chatRoomId(chatRoomId)
                 .senderId(userId)
                 .content(request.getContent())
                 .build();
-        // 메세지 저장 (자동)
+
         Message saved = messageRepository.save(message);
 
-        // 응답 DTO로 변환
+        // 상대 찾기
+        Long opponentId = chatParticipantRepository
+                .findFirstByChatRoomIdAndUserIdNot(chatRoomId, userId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND))
+                .getUserId();
+
+        // sender 기준 풀 DTO 조회
+        ChatRoomListItemProjection myRow =
+                chatParticipantRepository
+                        .findChatRoomListItemByUserIdAndRoomId(userId, chatRoomId)
+                        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        chatRoomListPushService.push(
+                userId,
+                new ChatRoomListItemResponse(
+                        myRow.getRoomId(),
+                        myRow.getOpponentUserId(),
+                        myRow.getOpponentImageUrl(),
+                        myRow.getLastMessageContent(),
+                        myRow.getLastMessageCreatedAt(),
+                        false
+                )
+        );
+
+        // opponent 기준 풀 DTO 조회
+        ChatRoomListItemProjection opponentRow =
+                chatParticipantRepository
+                        .findChatRoomListItemByUserIdAndRoomId(opponentId, chatRoomId)
+                        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        chatRoomListPushService.push(
+                opponentId,
+                new ChatRoomListItemResponse(
+                        opponentRow.getRoomId(),
+                        opponentRow.getOpponentUserId(),
+                        opponentRow.getOpponentImageUrl(),
+                        opponentRow.getLastMessageContent(),
+                        opponentRow.getLastMessageCreatedAt(),
+                        true
+                )
+        );
+
         return ChatMessageResponse.from(saved);
     }
+
 
     @Transactional(readOnly = true)
     public List<ChatMessageResponse> getMessagesByRoomId(Long chatRoomId, Long userId){

--- a/src/main/java/com/moayo/moayobackend/chat/service/ChatRoomListPushService.java
+++ b/src/main/java/com/moayo/moayobackend/chat/service/ChatRoomListPushService.java
@@ -1,0 +1,20 @@
+package com.moayo.moayobackend.chat.service;
+
+import com.moayo.moayobackend.chat.dto.response.ChatRoomListItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomListPushService {
+    private final SimpMessagingTemplate messagingTemplate; // subscriber 에게 message push
+
+    // 각 user별 message list update
+    public void push(Long userId, ChatRoomListItemResponse payload){
+        messagingTemplate.convertAndSend(
+                "/topic/chat/threads/" + userId,
+                payload
+        );
+    }
+}

--- a/src/main/java/com/moayo/moayobackend/chat/service/ChatRoomService.java
+++ b/src/main/java/com/moayo/moayobackend/chat/service/ChatRoomService.java
@@ -24,6 +24,8 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatParticipantRepository chatParticipantRepository;
     private final MessageRepository messageRepository;
+    private final ChatRoomListPushService chatRoomListPushService;
+
 
     @Transactional // user A와 user B 사이의 채팅방 id 반환 (없으면 방을 생성해 반환)
     public Long getOrCreateRoom(Long userAId, Long userBId) {
@@ -120,21 +122,32 @@ public class ChatRoomService {
             throw new ChatException(ChatErrorCode.CHAT_ROOM_FORBIDDEN);
         }
 
-        // 이 방의 마지막 메시지 ID 조회
-        var ids = messageRepository.findLastMessageIdsByRoomId(roomId);
-
-        // 메시지가 하나도 없으면 읽음 처리할 게 없으니 그냥 리턴
-        if (ids.isEmpty()) {
-            return;
+        if (roomId == null) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND); // 또는 ROOM_ID_REQUIRED 같은 코드
         }
 
-        Long lastMessageId = ids.get(0);
 
-        // 3. 내 참가자 row의 lastMessageId 업데이트
-        chatParticipantRepository.updateLastReadMessage(
-                roomId,
+        var ids = messageRepository.findLastMessageIdsByRoomId(roomId);
+        if (!ids.isEmpty()) {
+            Long lastMessageId = ids.get(0);
+            chatParticipantRepository.updateLastReadMessage(roomId, userId, lastMessageId);
+        }
+
+        ChatRoomListItemProjection row = chatParticipantRepository
+                .findChatRoomListItemByUserIdAndRoomId(userId, roomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 메세지 읽음 반영
+        chatRoomListPushService.push(
                 userId,
-                lastMessageId
+                new ChatRoomListItemResponse(
+                        row.getRoomId(),
+                        row.getOpponentUserId(),
+                        row.getOpponentImageUrl(),
+                        row.getLastMessageContent(),
+                        row.getLastMessageCreatedAt(),
+                        false
+                )
         );
     }
 }


### PR DESCRIPTION
## ✅ 작업 요약
- 채팅방 목록 Polling 제거 및 STOMP 기반 push 구조로의 전환 

## 🔗 관련 이슈
- Closes #161

## 🧩 주요 변경 사항
1. 채팅방 목록 Polling 제거
기존: 1.5초 간격 REST polling 방식
변경: STOMP 기반 push 구조로 전환
채팅방 목록 갱신 지연시간 평균 1.5초 → 0초 (실시간)

2. 읽음 처리 시 데이터 손실 문제 해결
기존: read 이벤트 push 시 content / createdAt / imageUrl null 전송
변경: Projection 기반 단건 조회 후 풀 DTO push 방식으로 통일

3.채팅방 목록 갱신 로직 통일
sendMessage / readChatRoom 모두 동일 Projection 쿼리 사용

## ✅ 체크리스트
- [ ] PR 대상 브랜치가 `develop` 인지 확인
- [ ] 커밋 컨벤션(Gitmoji + type + message) 준수
- [ ] 불필요한 로그/디버그 코드 제거
- [ ] 예외 처리 및 에러 코드 반영

---

### 👀 Review Rule (develop)
- develop 브랜치 PR은 **리뷰 승인 2회 이상 필수**
- 리뷰 코멘트 모두 해결 후 merge
